### PR TITLE
Fix fallback code and increase compatibility with older browsers

### DIFF
--- a/page/snapstream.ts
+++ b/page/snapstream.ts
@@ -23,6 +23,10 @@ function getCookie(key: string, defaultValue: string = ""): string {
     return defaultValue;
 }
 
+function getChromeVersion(): number | null {
+    const raw = navigator.userAgent.match(/Chrom(e|ium)\/([0-9]+)\./);
+    return raw ? parseInt(raw[2]) : null;
+}
 
 function uuidv4(): string {
     return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
@@ -519,8 +523,6 @@ class TimeProvider {
         if (ctx) {
             this.setAudioContext(ctx);
         }
-        let userAgent = navigator.userAgent.toLowerCase();
-        this.isFirefoxMobile = (userAgent.indexOf('firefox') > -1) && (userAgent.indexOf('android') > -1);
     }
 
     setAudioContext(ctx: AudioContext) {
@@ -551,11 +553,9 @@ class TimeProvider {
         if (!this.ctx) {
             return window.performance.now();
         } else {
-            if (this.isFirefoxMobile) {
-                return this.ctx.currentTime * 1000;
-            } else {
-                return (this.ctx.getOutputTimestamp().contextTime || this.ctx.currentTime) * 1000;
-            }
+            // Use the more accurate getOutputTimestamp if available, fallback to ctx.currentTime otherwise.
+            const contextTime = !!this.ctx.getOutputTimestamp ? this.ctx.getOutputTimestamp().contextTime : undefined;
+            return (contextTime !== undefined ? contextTime : this.ctx.currentTime) * 1000;
         }
     }
 
@@ -574,7 +574,6 @@ class TimeProvider {
     diffBuffer: Array<number> = new Array<number>();
     diff: number = 0;
     ctx: AudioContext | undefined;
-    isFirefoxMobile: boolean;
 }
 
 
@@ -827,7 +826,13 @@ class SnapStream {
                             this.bufferFrameCount = Math.floor(this.bufferDurationMs * this.sampleFormat.msRate());
                         }
                         this.stopAudio();
-                        this.ctx = new AudioContext({ latencyHint: "playback", sampleRate: this.sampleFormat.rate });
+                        let options: object | undefined = {latencyHint: "playback", sampleRate: this.sampleFormat.rate};
+                        const chromeVersion = getChromeVersion();
+                        if (chromeVersion !== null && chromeVersion < 55) {
+                            // Some older browsers won't decode the stream if options are provided.
+                            options = undefined;
+                        }
+                        this.ctx = new AudioContext(options);
                         this.timeProvider.setAudioContext(this.ctx);
                         this.gainNode = this.ctx.createGain();
                         this.gainNode.connect(this.ctx.destination);


### PR DESCRIPTION
* using `this.ctx.getOutputTimestamp().contextTime || (fallback)` does not have the intended effect of falling back if `getOutputTimestamp` doesn't exist because calling it throws a JS exception (infamous *undefined is not a function*). This fixes the problem by checking the function exists first.
* I'm running Snapweb on a smart TV with an ancient Chrome build (53.0 from 2016) and can only get it to work if `AudioContext` has no constructor options.