### PR TITLE
Make URL base configurable

### DIFF
--- a/page/config.ts
+++ b/page/config.ts
@@ -1,0 +1,3 @@
+let config = {
+    baseUrl: `ws://${window.location.hostname}:1780`
+}

--- a/page/index.html
+++ b/page/index.html
@@ -9,6 +9,7 @@
   <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
   <title>Snapweb</title>
   <script src="3rd-party/libflac.js"></script>
+  <script src="config.js"></script>
   <script src="snapstream.js"></script>
   <script src="snapcontrol.js"></script>
 </head>

--- a/page/snapcontrol.ts
+++ b/page/snapcontrol.ts
@@ -171,9 +171,9 @@ class Server {
 }
 
 class SnapControl {
-    constructor(host: string, port: number) {
+    constructor(baseUrl: string) {
         this.server = new Server();
-        this.connection = new WebSocket('ws://' + host + ':' + port + '/jsonrpc');
+        this.connection = new WebSocket(baseUrl + '/jsonrpc');
         this.msg_id = 0;
         this.status_req_id = -1;
         // console.log(navigator);
@@ -604,7 +604,7 @@ function play() {
         snapstream = null;
     }
     else {
-        snapstream = new SnapStream(window.location.hostname, 1780);
+        snapstream = new SnapStream(config.baseUrl);
     }
     show();
 }
@@ -724,7 +724,7 @@ function deleteClient(id: string) {
 }
 
 window.onload = function (event: any) {
-    snapcontrol = new SnapControl(window.location.hostname, 1780);
+    snapcontrol = new SnapControl(config.baseUrl);
 }
 
 // When the user clicks anywhere outside of the modal, close it

--- a/page/snapstream.ts
+++ b/page/snapstream.ts
@@ -816,8 +816,8 @@ class PcmDecoder extends Decoder {
 
 
 class SnapStream {
-    constructor(host: string, port: number) {
-        this.streamsocket = new WebSocket('ws://' + host + ':' + port + '/stream');
+    constructor(baseUrl: string) {
+        this.streamsocket = new WebSocket(baseUrl + '/stream');
         this.streamsocket.binaryType = "arraybuffer";
         this.streamsocket.onmessage = (msg: MessageEvent) => {
             let view = new DataView(msg.data);


### PR DESCRIPTION
Move base URL to config file (config.ts/js)
This is required when using a reverse proxy, running snapweb on a seperate host or running snapcast websocket on a different port. 