### PR TITLE
Auto-reconnect WebSockets if connection is lost

### DIFF
--- a/page/snapcontrol.ts
+++ b/page/snapcontrol.ts
@@ -173,14 +173,21 @@ class Server {
 class SnapControl {
     constructor(baseUrl: string) {
         this.server = new Server();
-        this.connection = new WebSocket(baseUrl + '/jsonrpc');
+        this.baseUrl = baseUrl;
         this.msg_id = 0;
         this.status_req_id = -1;
-        // console.log(navigator);
+        this.connect();
+    }
 
+    private connect(){
+        this.connection = new WebSocket(this.baseUrl + '/jsonrpc');
         this.connection.onmessage = (msg: MessageEvent) => this.onMessage(msg.data);
-        this.connection.onopen = (ev: Event) => { this.status_req_id = this.sendRequest('Server.GetStatus'); }
-        this.connection.onerror = (ev: Event) => { alert("error: " + ev.type); }//this.onError(ev);
+        this.connection.onopen = (ev: Event) => { this.status_req_id = this.sendRequest('Server.GetStatus'); };
+        this.connection.onerror = (ev: Event) => { console.error('error:', ev); };
+        this.connection.onclose = (ev: Event) => {
+            console.info('connection lost, reconnecting in 1s'); 
+            setTimeout(() => this.connect(), 1000);
+        };
     }
 
     private action(answer: any) {
@@ -347,7 +354,8 @@ class SnapControl {
         }
     }
 
-    connection: WebSocket;
+    baseUrl: string;
+    connection!: WebSocket;
     server: Server;
     msg_id: number;
     status_req_id: number;

--- a/page/snapstream.ts
+++ b/page/snapstream.ts
@@ -814,11 +814,11 @@ class PcmDecoder extends Decoder {
 class SnapStream {
     constructor(baseUrl: string) {
         this.baseUrl = baseUrl;
-        this.connect();
         this.timeProvider = new TimeProvider();
+        this.connect();
     }
 
-    private connect(){
+    private connect() {
         this.streamsocket = new WebSocket(this.baseUrl + '/stream');
         this.streamsocket.binaryType = "arraybuffer";
         this.streamsocket.onmessage = (ev) => this.onMessage(ev);
@@ -839,7 +839,7 @@ class SnapStream {
         this.streamsocket.onerror = (ev) => { console.error('error:', ev); };
         this.streamsocket.onclose = (ev) => {
             window.clearInterval(this.syncHandle);
-            console.info('connection lost, reconnecting in 1s'); 
+            console.info('connection lost, reconnecting in 1s');
             setTimeout(() => this.connect(), 1000);
         }
     }
@@ -958,7 +958,7 @@ class SnapStream {
         window.clearInterval(this.syncHandle);
         this.stopAudio();
         if ([WebSocket.OPEN, WebSocket.CONNECTING].includes(this.streamsocket.readyState)) {
-            this.streamsocket.onclose = (ev) => {};
+            this.streamsocket.onclose = (ev) => { };
             this.streamsocket.close();
         }
     }

--- a/page/snapstream.ts
+++ b/page/snapstream.ts
@@ -960,6 +960,7 @@ class SnapStream {
         window.clearInterval(this.syncHandle);
         this.stopAudio();
         if ([WebSocket.OPEN, WebSocket.CONNECTING].includes(this.streamsocket.readyState)) {
+            this.streamsocket.onclose = (ev) => {};
             this.streamsocket.close();
         }
     }

--- a/page/snapstream.ts
+++ b/page/snapstream.ts
@@ -928,9 +928,7 @@ class SnapStream {
         msg.sent = new Tv(0, 0);
         msg.sent.setMilliseconds(this.timeProvider.now());
         msg.id = ++this.msgId;
-        if (this.streamsocket.readyState != this.streamsocket.OPEN) {
-            stop();
-        } else {
+        if (this.streamsocket.readyState == this.streamsocket.OPEN) {
             this.streamsocket.send(msg.serialize());
         }
     }


### PR DESCRIPTION
If the WebSocket connection is lost (e.g. after putting laptop to sleep), snapweb shows the old snapserver state and user input doesn't so anything.

This PR makes snapweb retry connecting the websocket connections every second after it has been lost.

By pure chance, this also fixes #19 (see issue for details)