### PR TITLE
allow use of (https) reverse proxies by default

### DIFF
--- a/page/config.ts
+++ b/page/config.ts
@@ -1,3 +1,3 @@
 let config = {
-    baseUrl: `ws://${window.location.hostname}:1780`
+    baseUrl: (window.location.protocol === 'https:' ? 'wss://' : 'ws://') + window.location.host
 }


### PR DESCRIPTION
Use the snapweb URL for connecting to the websockets by default.
This allows running snapweb behind a reverse proxy but might break existing installations if snapweb is not running in the snapserver's web server.

fixes #21 