### PR TITLE
Remove blue highlights from elements

### DIFF
--- a/page/styles.css
+++ b/page/styles.css
@@ -28,6 +28,10 @@ body {
     background: #555;
 }
 
+input, textarea, button, select, a {
+    -webkit-tap-highlight-color: rgba(0,0,0,0);
+}
+
 .navbar {
     overflow: hidden;
     background-color: #607d8b;


### PR DESCRIPTION
This will remove the blue highlights that appear on buttons when they are pressed (on mobile).

![Screenshot_2021-08-19_16-24-10](https://user-images.githubusercontent.com/36895504/130077723-1ffbf380-cbb7-4598-842a-9906858c302a.png)
