### PR TITLE
Small bugfix for typescript compilation error

### DIFF
--- a/page/snapstream.ts
+++ b/page/snapstream.ts
@@ -985,7 +985,8 @@ class SnapStream {
     public stop() {
         window.clearInterval(this.syncHandle);
         this.stopAudio();
-        if ([WebSocket.OPEN, WebSocket.CONNECTING].includes(this.streamsocket.readyState)) {
+        if (this.streamsocket.readyState == WebSocket.OPEN ||
+            this.streamsocket.readyState == WebSocket.CONNECTING) {
             this.streamsocket.onclose = () => { };
             this.streamsocket.close();
         }


### PR DESCRIPTION
I found a typescript error, this change fixes it:

```
$ make
tsc --build page/tsconfig.json
page/snapstream.ts:988:61 - error TS2345: Argument of type 'number' is not assignable to parameter of type '0 | 1'.

988         if ([WebSocket.OPEN, WebSocket.CONNECTING].includes(this.streamsocket.readyState)) {
                                                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~


Found 1 error.

make: *** [Makefile:6: tsc] Error 1
```

Other userful details:
```
$ tsc --version
Version 5.1.6
$ node --version
v18.13.0
$ npm --version
9.2.0
```
