### PR TITLE
build with relative base URL

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,7 @@ import { VitePWA } from 'vite-plugin-pwa';
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  base: './',
   plugins: [react(),
   VitePWA({
     registerType: 'autoUpdate',


### PR DESCRIPTION
snapweb was built using the absolute path `/` as base URL (default), making asset links absolute. However, hard-coding an absolute base path prevents serving snapweb under a different path, e.g. exposing snapweb under `/snapcast/` via a reverse-proxy.
To support those kinds of setups, snapweb is built with a relative base URL `./` now.

**TL;DR:**
In the Makefile-based Snapcast 0.27.0 build I used previously the asset paths were still relative. For me it broke with the update to Snapcast 0.28.0 when using the snapweb v0.7.0 zip distribution explicitly.