### PR TITLE
Improve audio latency

### DIFF
--- a/src/snapstream.ts
+++ b/src/snapstream.ts
@@ -18,8 +18,9 @@ interface IAudioContextPatched extends IAudioContext {
 
 class AudioContextPatched extends AudioContext implements IAudioContextPatched {
     get outputLatency(): number {
-        if (this._nativeAudioContext!.outputLatency !== undefined) {
-            return this._nativeAudioContext.outputLatency;
+        const ctx = (<any>this)._nativeAudioContext;
+        if (ctx && ctx.outputLatency !== undefined) {
+            return ctx.outputLatency;
         }
         return 0;
     }

--- a/src/snapstream.ts
+++ b/src/snapstream.ts
@@ -16,6 +16,15 @@ interface IAudioContextPatched extends IAudioContext {
     readonly outputLatency: number;
 }
 
+class AudioContextPatched extends AudioContext implements IAudioContextPatched {
+    get outputLatency(): number {
+        if (this._nativeAudioContext!.outputLatency !== undefined) {
+            return this._nativeAudioContext.outputLatency;
+        }
+        return 0;
+    }
+}
+
 function getChromeVersion(): number | null {
     const raw = navigator.userAgent.match(/Chrom(e|ium)\/([0-9]+)\./);
     return raw ? parseInt(raw[2]) : null;
@@ -824,7 +833,7 @@ class SnapStream {
                 options = undefined;
             }
 
-            this.ctx = new AudioContext(options) as IAudioContextPatched;
+            this.ctx = new AudioContextPatched(options);
             this.gainNode = this.ctx.createGain();
             this.gainNode.connect(this.ctx.destination);
         } else {

--- a/src/snapstream.ts
+++ b/src/snapstream.ts
@@ -825,7 +825,7 @@ class SnapStream {
     private setupAudioContext(): boolean {
         if (AudioContext) {
             let options: AudioContextOptions | undefined;
-            options = { latencyHint: "playback", sampleRate: this.sampleFormat ? this.sampleFormat.rate : undefined };
+            options = { latencyHint: "interactive", sampleRate: this.sampleFormat ? this.sampleFormat.rate : undefined };
 
             const chromeVersion = getChromeVersion();
             if ((chromeVersion !== null && chromeVersion < 55) || !window.AudioContext) {


### PR DESCRIPTION
This PR makes two improvements to the SnapWeb audio stream latency handling.

As the `standardized-audio-context` doesn't expose the `outputLatency` property, the first commits adds a getter that tries to fetch the `AudioContext.outputLatency` from the native AudioContext, if it exists. It improves the sync between SnapWeb and other (non-web) Snapcast clients dramatically.

The second commit sets the latencyHint of the AudioContext to "interactive". This not only reduces the output latency on most systems, but seems to make the output latency also more stable. On some platforms, the output latency varies over time depending on system load and other factors. Using "interactive" seems to make this a little less likely.

Tested on recent Chrome and Firefox on Linux. More tests would probably be a good idea.