### PR TITLE
Implement opusdecoder with wasm-opus-decoder

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,15 +16,16 @@
     "@mui/icons-material": "^6.4.6",
     "@mui/material": "^6.4.6",
     "libflacjs": "^5.4.0",
+    "opus-decoder": "^0.7.7",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "standardized-audio-context": "^25.3.77"
   },
   "devDependencies": {
     "@eslint/js": "^9.21.0",
+    "@types/node": "^22.13.8",
     "@types/react": "^19.0.10",
     "@types/react-dom": "^19.0.4",
-    "@types/node": "^22.13.8",
     "@vite-pwa/assets-generator": "^0.2.6",
     "@vitejs/plugin-react-swc": "^3.8.0",
     "eslint": "^9.21.0",


### PR DESCRIPTION
This pull request includes significant updates to the `src/snapstream.ts` file and minor updates to the `package.json` file. The main focus is on integrating the `opus-decoder` library and enhancing the `OpusDecoder` class to support asynchronous decoding.

Integration of `opus-decoder` library:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R19-L27): Added `opus-decoder` to dependencies.
* [`src/snapstream.ts`](diffhunk://#diff-efbf1bc2cdf3136908043e2369c7cd1292d29a2f75660bf8646fe5e75fb29b28R4): Imported `OpusDecoder` from `opus-decoder`.

Enhancements to `OpusDecoder` class:

* [`src/snapstream.ts`](diffhunk://#diff-efbf1bc2cdf3136908043e2369c7cd1292d29a2f75660bf8646fe5e75fb29b28R743-R817): Re-implemented `OpusDecoder` class to initialize the WebAssembly-based Opus decoder and support asynchronous decoding.
* [`src/snapstream.ts`](diffhunk://#diff-efbf1bc2cdf3136908043e2369c7cd1292d29a2f75660bf8646fe5e75fb29b28L928-R984): Updated `SnapStream` class to handle the new asynchronous `decode` method of `OpusDecoder`.

Removal of deprecated code:

* [`src/snapstream.ts`](diffhunk://#diff-efbf1bc2cdf3136908043e2369c7cd1292d29a2f75660bf8646fe5e75fb29b28L622-R623): Removed the old `OpusDecoder` class implementation.