### PR TITLE
Declare "playback" as audioSession.type, fixes #161 (iOS audio playback in background)

### DIFF
--- a/src/components/SnapWeb.tsx
+++ b/src/components/SnapWeb.tsx
@@ -113,6 +113,11 @@ export default function SnapWeb() {
     setTheme(config.theme);
   });
 
+  // Set AudioSession type to playback to enable background playback on iOS
+  if ("audioSession" in navigator) {
+  	((navigator.audioSession as any).type as string) = "playback";
+  }
+
   useEffect(() => {
     console.debug("server updated");
   }, [server]);


### PR DESCRIPTION
By default, iOS does not allow Javascript audio to be played when the website is not in the foreground. This can be mitigated by declaring audioSession.type as "playback" in the experimental AudioSessionAPI as described under https://developer.mozilla.org/en-US/docs/Web/API/AudioSession. This is tested to fix #161.

This PR does exactly this. I hope SnapWeb.tsx is the right place to do so.

As I'm not very experienced in typescript, I just casted `navigator.audioSession` to `any` to avoid compile errors. This should not be a poblem I think because we check for it's existence beforehand and by the API specification it is guaranteed to have the type attribute which is a string. If there is a better way to do this, please let me know :)