### PR TITLE
Fix time-sync median: sort clock offsets numerically

### DIFF
--- a/src/snapstream.ts
+++ b/src/snapstream.ts
@@ -549,7 +549,7 @@ class TimeProvider {
             if (this.diffBuffer.push((c2s - s2c) / 2) > 100)
                 this.diffBuffer.shift();
             const sorted = [...this.diffBuffer];
-            sorted.sort()
+            sorted.sort((a, b) => a - b);
             this.diff = sorted[Math.floor(sorted.length / 2)];
         }
         // console.debug("c2s: " + c2s.toFixed(2) + ", s2c: " + s2c.toFixed(2) + ", diff: " + this.diff.toFixed(2) + ", now: " + this.now().toFixed(2) + ", server.now: " + this.serverNow().toFixed(2) + ", win.now: " + window.performance.now().toFixed(2));


### PR DESCRIPTION
TimeProvider.setDiff computes the median client/server clock offset to drive audio/video synchronization, but sorted the offset buffer with a bare Array.prototype.sort(). With no comparator, sort() coerces elements to strings and orders them lexicographically, so the "median" was taken from a wrongly ordered array (e.g. [2, 10, -5, 100] -> [-5, 10, 100, 2]).

The resulting offset is unstable and frequently wrong, corrupting every serverTime() calculation and causing playback drift and "Chunk too old, dropping" stalls.

Sort numerically with an explicit comparator.